### PR TITLE
Generalize email address and password for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ require 'kindle_highlights'
 
 # pass in your Amazon credentials. Loads your books (not highlights)
 # on init, so might take a while
-kindle = KindleHighlights::Client.new("sgt.pepper@lonelyhearts.com", "mr_kite")
+kindle = KindleHighlights::Client.new("email.address@gmail.com", "password")
 
 # returns a hash of your books, keyed on the ASIN, with the title as value
 kindle.books #=>


### PR DESCRIPTION
Also, changed the file extension to `.md`, which is standard Markdown. Might break links, so happy to revert if so. First step to fixing https://github.com/speric/kindle-highlights/issues/4.
