### PR TITLE
Access to domains other than read.amazon.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ kindle = KindleHighlights::Client.new(
 )
 ```
 
+Or you can use `read.amazon.com` equivalents provided on other TLDs like:
+
+```ruby
+kindle = KindleHighlights::Client.new(
+  email_address: "me@example.com",
+  password: "amazon_password",\
+  root_url: 'https://read.amazon.co.jp'
+)
+```
+
 ### A Note About CAPTCHAs
 
 Amazon will sometimes issue a CAPTCHA challenge when logging in to your

--- a/lib/kindle_highlights.rb
+++ b/lib/kindle_highlights.rb
@@ -3,10 +3,6 @@ require 'mechanize'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/string/filters'
 
-module KindleHighlights
-  KINDLE_ROOT = "https://read.amazon.com"
-end
-
 require_relative './kindle_highlights/client'
 require_relative './kindle_highlights/book'
 require_relative './kindle_highlights/highlight'

--- a/lib/kindle_highlights.rb
+++ b/lib/kindle_highlights.rb
@@ -3,6 +3,10 @@ require 'mechanize'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/string/filters'
 
+module KindleHighlights
+  KINDLE_ROOT = "https://read.amazon.com"
+end
+
 require_relative './kindle_highlights/client'
 require_relative './kindle_highlights/book'
 require_relative './kindle_highlights/highlight'

--- a/lib/kindle_highlights/book.rb
+++ b/lib/kindle_highlights/book.rb
@@ -38,7 +38,7 @@ module KindleHighlights
 
     def fetch_highlights_from_amazon
       mechanize_agent
-        .get("https://read.amazon.com/kp/notebook?captcha_verified=1&asin=#{asin}&contentLimitState=&")
+        .get("#{KindleHighlights::KINDLE_ROOT}/kp/notebook?captcha_verified=1&asin=#{asin}&contentLimitState=&")
         .search("div#kp-notebook-annotations")
         .children
         .select { |child| child.name == "div" }

--- a/lib/kindle_highlights/book.rb
+++ b/lib/kindle_highlights/book.rb
@@ -1,9 +1,10 @@
 module KindleHighlights
   class Book
-    attr_accessor :asin, :author, :title
+    attr_accessor :asin, :author, :title, :root_url
 
-    def self.from_html_elements(html_element:, mechanize_agent:)
+    def self.from_html_elements(html_element:, root_url:, mechanize_agent:)
       new(
+        root_url: root_url,
         mechanize_agent: mechanize_agent,
         asin: html_element.attributes["id"].value.squish,
         title: html_element.children.search("h2").first.text.squish,
@@ -11,10 +12,11 @@ module KindleHighlights
       )
     end
 
-    def initialize(asin:, author:, title:, mechanize_agent: nil)
+    def initialize(asin:, author:, title:, root_url:, mechanize_agent: nil)
       @asin = asin
       @author = author
       @title = title
+      @root_url = root_url
       @mechanize_agent = mechanize_agent
     end
 
@@ -38,7 +40,7 @@ module KindleHighlights
 
     def fetch_highlights_from_amazon
       mechanize_agent
-        .get("#{KindleHighlights::KINDLE_ROOT}/kp/notebook?captcha_verified=1&asin=#{asin}&contentLimitState=&")
+        .get("#{root_url}/kp/notebook?captcha_verified=1&asin=#{asin}&contentLimitState=&")
         .search("div#kp-notebook-annotations")
         .children
         .select { |child| child.name == "div" }

--- a/lib/kindle_highlights/client.rb
+++ b/lib/kindle_highlights/client.rb
@@ -4,7 +4,6 @@ module KindleHighlights
     class AuthenticationError < StandardError; end
     class AsinNotFoundError < StandardError; end
 
-    KINDLE_LOGIN_PAGE      = "https://read.amazon.com/notebook"
     SIGNIN_FORM_IDENTIFIER = "signIn"
     MAX_AUTH_RETRIES       = 2
 
@@ -83,7 +82,7 @@ module KindleHighlights
     end
 
     def login_via_mechanize
-      signin_page = mechanize_agent.get(KINDLE_LOGIN_PAGE)
+      signin_page = mechanize_agent.get("#{KindleHighlights::KINDLE_ROOT}/notebook")
       signin_form = signin_page.form(SIGNIN_FORM_IDENTIFIER)
       signin_form.email = email_address
       signin_form.password = password

--- a/lib/kindle_highlights/client.rb
+++ b/lib/kindle_highlights/client.rb
@@ -8,13 +8,16 @@ module KindleHighlights
     MAX_AUTH_RETRIES       = 2
 
     attr_writer :mechanize_agent, :kindle_logged_in_page
+    attr_reader :root_url, :kindle_login_page
 
-    def initialize(email_address:, password:, mechanize_options: {})
+    def initialize(email_address:, password:, root_url: "https://read.amazon.com", mechanize_options: {})
       @email_address = email_address
       @password = password
       @mechanize_options = mechanize_options
       @retries = 0
       @kindle_logged_in_page = nil
+      @root_url = root_url
+      @kindle_login_page = "#{@root_url}/notebook"
     end
 
     def books
@@ -54,7 +57,7 @@ module KindleHighlights
 
       kindle_library.map do |book|
         unless book.attributes["id"].blank?
-          Book.from_html_elements(html_element: book, mechanize_agent: mechanize_agent)
+          Book.from_html_elements(html_element: book, mechanize_agent: mechanize_agent, root_url: root_url)
         end
       end.compact
     end
@@ -82,7 +85,7 @@ module KindleHighlights
     end
 
     def login_via_mechanize
-      signin_page = mechanize_agent.get("#{KindleHighlights::KINDLE_ROOT}/notebook")
+      signin_page = mechanize_agent.get(@kindle_login_page)
       signin_form = signin_page.form(SIGNIN_FORM_IDENTIFIER)
       signin_form.email = email_address
       signin_form.password = password

--- a/test/change_domain_test.rb
+++ b/test/change_domain_test.rb
@@ -1,11 +1,12 @@
 require 'kindle_highlights'
 require 'minitest/autorun'
 
-class FetchingBooksAndHighlightsTest < Minitest::Test
+class ChangeDomainTest < Minitest::Test
   def setup
     @kindle = KindleHighlights::Client.new(
       email_address: "amazon@example.com",
-      password: "letmein"
+      password: "letmein",
+      root_url: "https://read.amazon.co.example"
     )
     @kindle.mechanize_agent = FakeMechanizeAgent.new
     @kindle.kindle_logged_in_page = Mechanize::Page.new(
@@ -17,30 +18,12 @@ class FetchingBooksAndHighlightsTest < Minitest::Test
     )
   end
 
-  def test_fetching_books_from_kindle_account
-    assert_equal 1, @kindle.books.count
-
-    book = @kindle.books.first
-    assert_equal "B000XUAETY", book.asin
-    assert_equal "James R. Mcdonough", book.author
-    assert_equal "Platoon Leader: A Memoir of Command in Combat", book.title
-    assert_equal "https://read.amazon.com", book.root_url
+  def test_client_root_url
+    assert_equal "https://read.amazon.co.example", @kindle.root_url
   end
 
-  def test_fetching_highlights_for_a_book
-    highlights = @kindle.highlights_for("B000XUAETY")
-    assert_equal 1, highlights.count
-
-    highlight = highlights.first
-    assert_equal "306", highlight.location
-    assert_equal "Destiny is not born of decision; it is born of uncontrollable circumstances.", highlight.text
-    assert_equal "B000XUAETY", highlight.asin
-  end
-
-  def test_fetching_highlights_for_a_non_existing_asin
-    assert_raises KindleHighlights::Client::AsinNotFoundError do
-      @kindle.highlights_for("BADASIN")
-    end
+  def test_book_root_url
+    assert_equal "https://read.amazon.co.example", @kindle.books.first.root_url
   end
 
   def raw_signin_page


### PR DESCRIPTION
Unlike the old `kindle.amazon.com` website, 
`read.amazon.com` equivalents are available on some other ccTLD amazon e.g. `read.amazon.co.jp`.
So I want to scrape them from the gem.

Monkeypatching the const allows you to scrape amazon besides `https://read.amazon.com`.

```ruby
KindleHighlights::KINDLE_ROOT = "https://read.amazon.co.jp"

KindleHighlights::Client.new(...).books # fetch books from amazon.co.jp
```